### PR TITLE
refactor: replace all filled button with `AdaptivePrimaryButton` fron widgetBook

### DIFF
--- a/lib/src/core/common/sections/navigation_footer_section.dart
+++ b/lib/src/core/common/sections/navigation_footer_section.dart
@@ -1,13 +1,13 @@
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:go_router/go_router.dart';
-import 'package:gui/src/core/common/colors/app_colors.dart';
 import 'package:gui/src/core/common/widgets/adaptive_text_button.dart';
-import 'package:gui/src/core/common/widgets/custom_filled_button.dart';
-import 'package:gui/src/core/common/widgets/custom_outlined_button.dart';
 import 'package:gui/src/core/router/route_name.dart';
 import 'package:gui/src/core/utils/gen/localization/locale_keys.dart';
 import 'package:gui/src/features/main/language/core/localization_extension.dart';
 import 'package:pactus_gui_widgetbook/app_styles.dart';
+import 'package:pactus_gui_widgetbook/src/features/widgets/buttons/adaptive_primary_button/adaptive_primary_button.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/request_state_enum.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/padding_size_enum.dart';
 
 class NavigationFooterSection extends StatelessWidget {
   const NavigationFooterSection({
@@ -40,19 +40,43 @@ class NavigationFooterSection extends StatelessWidget {
         children: [
           // Always reserve space for Back button
           if (selectedIndex > 0 && onBackPressed != null)
-            CustomOutlinedButton(
-              text: context.tr(LocaleKeys.back),
-              onPressed: onBackPressed,
-              borderColor: AppColors.primaryGray,
-            )
+            IntrinsicWidth(
+              child: SizedBox(
+                height: 32,
+            child: AdaptivePrimaryButton.createTitleOnly(
+                  requestState: RequestStateEnum.loaded,
+                  onPressed: onBackPressed,
+                  title: context.tr(LocaleKeys.back),
+                  isOutlined: true,
+                ),
+          ),
+        )
+    // CustomOutlinedButton(
+    //           text: context.tr(LocaleKeys.back),
+    //           onPressed: onBackPressed,
+    //           borderColor: AppColors.primaryGray,
+    //         )
           else
-            CustomOutlinedButton(
-              text: context.tr(LocaleKeys.back),
-              onPressed: () {
-                context.goNamed(AppRoute.initializeMode.name);
-              },
-              borderColor: AppColors.primaryGray,
+            IntrinsicWidth(
+              child: SizedBox(
+                height: 32,
+                child: AdaptivePrimaryButton.createTitleOnly(
+                  requestState: RequestStateEnum.loaded,
+                  onPressed: () {
+                    context.goNamed(AppRoute.initializeMode.name);
+                  },
+                  title: context.tr(LocaleKeys.back),
+                  isOutlined: true,
+                ),
+              ),
             ),
+            // CustomOutlinedButton(
+            //   text: context.tr(LocaleKeys.back),
+            //   onPressed: () {
+            //     context.goNamed(AppRoute.initializeMode.name);
+            //   },
+            //   borderColor: AppColors.primaryGray,
+            // ),
 
           // Modified Next button section with optional Skip
           Row(
@@ -65,14 +89,16 @@ class NavigationFooterSection extends StatelessWidget {
                 ),
                 const SizedBox(width: 10),
               ],
-              CustomFilledButton(
-                text: 'Next',
-                style: ButtonStyle(
-                  backgroundColor: WidgetStateProperty.all<Color?>(
-                    FluentTheme.of(context).accentColor,
+              IntrinsicWidth(
+                child: SizedBox(
+                  height: 32,
+                  child: AdaptivePrimaryButton.createTitleOnly(
+                    requestState: RequestStateEnum.loaded,
+                    onPressed: selectedIndex < 6 ? onNextPressed : null,
+                    title: context.tr(LocaleKeys.next),
+                    paddingSize: PaddingSizeEnum.large,
                   ),
                 ),
-                onPressed: selectedIndex < 6 ? onNextPressed : null,
               ),
             ],
           ),

--- a/lib/src/features/finish/presentation/screen/finish_screen.dart
+++ b/lib/src/features/finish/presentation/screen/finish_screen.dart
@@ -16,6 +16,8 @@ import 'package:gui/src/core/utils/methods/update_node_details_singleton.dart';
 import 'package:gui/src/core/utils/string_extension.dart';
 import 'package:gui/src/features/main/language/core/localization_extension.dart';
 import 'package:pactus_gui_widgetbook/app_styles.dart';
+import 'package:pactus_gui_widgetbook/src/features/widgets/buttons/adaptive_primary_button/adaptive_primary_button.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/request_state_enum.dart';
 
 class FinishScreen extends StatefulWidget {
   const FinishScreen({super.key});
@@ -94,10 +96,12 @@ class _FinishScreenState extends State<FinishScreen> {
                     ),
                     Align(
                       alignment: AlignmentDirectional.bottomCenter,
-                      child: CustomFilledButton(
-                        text: LocaleKeys.go_to_dashboard,
-                        onPressed: () {
-                          context.read<DaemonCubit>().runStartNodeCommand(
+                      child: IntrinsicWidth(
+                        child: SizedBox(
+                          height: 32,
+                          child: AdaptivePrimaryButton.createTitleOnly(
+                            onPressed: () {
+                              context.read<DaemonCubit>().runStartNodeCommand(
                                 cliCommand: CliCommand(
                                   command: CliConstants.pactusDaemon,
                                   arguments: [
@@ -110,15 +114,14 @@ class _FinishScreenState extends State<FinishScreen> {
                                 ),
                               );
 
-                          updateNodeDetailsSingleton(
-                            NodeConfigData.instance.password,
-                          );
+                              updateNodeDetailsSingleton(
+                                NodeConfigData.instance.password,
+                              );
 
-                          context.go(AppRoute.dashboard.fullPath);
-                        },
-                        style: ButtonStyle(
-                          backgroundColor: WidgetStateProperty.all<Color?>(
-                            FluentTheme.of(context).accentColor,
+                              context.go(AppRoute.dashboard.fullPath);
+                            },
+                            requestState: RequestStateEnum.loaded,
+                            title: context.tr(LocaleKeys.go_to_dashboard,),
                           ),
                         ),
                       ),

--- a/lib/src/features/generation_seed/presentation/widgets/copy_to_clip_board_button.dart
+++ b/lib/src/features/generation_seed/presentation/widgets/copy_to_clip_board_button.dart
@@ -1,9 +1,12 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:go_router/go_router.dart';
 import 'package:gui/src/core/common/colors/app_colors.dart';
 import 'package:gui/src/core/common/widgets/adaptive_filled_button.dart';
 import 'package:gui/src/core/utils/gen/localization/locale_keys.dart';
 import 'package:gui/src/features/main/language/core/localization_extension.dart';
 import 'package:pactus_gui_widgetbook/app_styles.dart';
+import 'package:pactus_gui_widgetbook/src/features/widgets/buttons/adaptive_primary_button/adaptive_primary_button.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/request_state_enum.dart';
 
 /// ## [CopyToClipboardButton] Class Documentation
 ///
@@ -64,6 +67,7 @@ class CopyToClipboardButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    /// to-do : replace with adaptive text button here
     return Align(
       alignment: Alignment.centerRight,
       child: AdaptiveFilledButton(
@@ -95,16 +99,17 @@ class CopyToClipboardButton extends StatelessWidget {
                     .copyWith(color: AppColors.primaryDark),
               ),
               actions: [
-                AdaptiveFilledButton(
-                  text: context.tr(LocaleKeys.ok),
-                  onPressed: () {
-                    if (context.mounted) {
-                      Navigator.pop(context);
-                    }
-                  },
-                  style: ButtonStyle(
-                    backgroundColor: WidgetStateProperty.all<Color?>(
-                      FluentTheme.of(context).accentColor,
+                IntrinsicWidth(
+                  child: SizedBox(
+                    height: 32,
+                    child: AdaptivePrimaryButton.createTitleOnly(
+                      onPressed: () {
+                        if (context.mounted) {
+                          Navigator.pop(context);
+                        }
+                      },
+                      requestState: RequestStateEnum.loaded,
+                      title: context.tr(LocaleKeys.ok),
                     ),
                   ),
                 ),

--- a/lib/src/features/initialize_mode/presentation/screen/initialize_mode_screen.dart
+++ b/lib/src/features/initialize_mode/presentation/screen/initialize_mode_screen.dart
@@ -14,6 +14,9 @@ import 'package:gui/src/features/main/navigation_pan_cubit/presentation/cubits/n
 import 'package:gui/src/features/main/radio_button_cubit/presentation/radio_button_cubit.dart';
 import 'package:gui/src/features/validator_config/core/utils/methods/show_fluent_alert_method.dart';
 import 'package:pactus_gui_widgetbook/app_styles.dart';
+import 'package:pactus_gui_widgetbook/src/features/widgets/buttons/adaptive_primary_button/adaptive_primary_button.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/request_state_enum.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/padding_size_enum.dart';
 
 /// ## [InitializeModeScreen] Class Documentation
 ///
@@ -166,19 +169,31 @@ class _InitializeModeScreenState extends State<InitializeModeScreen> {
                         alignment: Alignment.centerRight,
                         child: BlocBuilder<RadioButtonCubit, int>(
                           builder: (context, selectedValue) {
-                            return AdaptiveFilledButton(
-                              text: context.tr(LocaleKeys.next),
-                              onPressed: () =>
-                                  _handleNextPressed(selectedValue),
-                              style: ButtonStyle(
-                                backgroundColor: WidgetStatePropertyAll(
-                                  FluentTheme.of(context).accentColor,
-                                ),
-                                padding: WidgetStatePropertyAll(
-                                  const EdgeInsets.symmetric(horizontal: 16),
+                            return  IntrinsicWidth(
+                              child: SizedBox(
+                                height: 32,
+                                child: AdaptivePrimaryButton.createTitleOnly(
+                                  requestState: RequestStateEnum.loaded,
+                                  onPressed: () =>
+                                      _handleNextPressed(selectedValue),
+                                  title: context.tr(LocaleKeys.next),
+                                  paddingSize: PaddingSizeEnum.large,
                                 ),
                               ),
                             );
+                            //   AdaptiveFilledButton(
+                            //   text: context.tr(LocaleKeys.next),
+                            //   onPressed: () =>
+                            //       _handleNextPressed(selectedValue),
+                            //   style: ButtonStyle(
+                            //     backgroundColor: WidgetStatePropertyAll(
+                            //       FluentTheme.of(context).accentColor,
+                            //     ),
+                            //     padding: WidgetStatePropertyAll(
+                            //       const EdgeInsets.symmetric(horizontal: 16),
+                            //     ),
+                            //   ),
+                            // );
                           },
                         ),
                       ),

--- a/lib/src/features/validator_config/presentation/screen/validator_config_screen.dart
+++ b/lib/src/features/validator_config/presentation/screen/validator_config_screen.dart
@@ -20,6 +20,8 @@ import 'package:gui/src/features/validator_config/core/utils/methods/show_fluent
 import 'package:gui/src/features/validator_config/presentation/sections/validator_config_title_section.dart';
 import 'package:gui/src/features/validator_config/presentation/sections/validator_qty_selector_section.dart';
 import 'package:pactus_gui_widgetbook/app_styles.dart';
+import 'package:pactus_gui_widgetbook/src/features/widgets/buttons/adaptive_primary_button/adaptive_primary_button.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/request_state_enum.dart';
 
 /// ## [ValidatorConfigScreen] Class Documentation
 ///
@@ -125,19 +127,13 @@ class _ValidatorConfigScreenState extends State<ValidatorConfigScreen> {
                       ),
                     ),
                     const Gap(28),
-                    CustomFilledButton(
-                      text: context.tr(LocaleKeys.select_folder),
-                      onPressed: _chooseDirectory,
-                      style: ButtonStyle(
-                        padding:
-                            WidgetStateProperty.all<EdgeInsetsDirectional?>(
-                          const EdgeInsetsDirectional.symmetric(
-                            horizontal: 8,
-                            vertical: 4,
-                          ),
-                        ),
-                        backgroundColor: WidgetStateProperty.all<Color?>(
-                          FluentTheme.of(context).accentColor,
+                    IntrinsicWidth(
+                      child: SizedBox(
+                        height: 32,
+                        child: AdaptivePrimaryButton.createTitleOnly(
+                          onPressed: _chooseDirectory,
+                          requestState: RequestStateEnum.loaded,
+                          title: context.tr(LocaleKeys.select_folder),
                         ),
                       ),
                     ),

--- a/lib/src/features/welcome/presentation/screen/welcome_screen.dart
+++ b/lib/src/features/welcome/presentation/screen/welcome_screen.dart
@@ -3,13 +3,14 @@ import 'package:flutter/foundation.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gui/src/core/common/widgets/accent_color_picker_widget.dart';
-import 'package:gui/src/core/common/widgets/adaptive_text_button.dart';
 import 'package:gui/src/core/common/widgets/app_layout.dart';
 import 'package:gui/src/core/router/route_name.dart';
 import 'package:gui/src/core/utils/gen/assets/assets.gen.dart';
 import 'package:gui/src/core/utils/gen/localization/locale_keys.dart';
 import 'package:gui/src/features/main/language/core/localization_extension.dart';
 import 'package:pactus_gui_widgetbook/app_styles.dart';
+import 'package:pactus_gui_widgetbook/src/features/widgets/buttons/adaptive_primary_button/adaptive_primary_button.dart';
+import 'package:pactus_gui_widgetbook/src/core/enum/request_state_enum.dart';
 
 class WelcomeScreen extends StatelessWidget {
   const WelcomeScreen({super.key});
@@ -49,21 +50,19 @@ class WelcomeScreen extends StatelessWidget {
                 const AccentColorPicker(),
               ],
               const Gap(16),
-              AdaptiveTextButton(
-                style: ButtonStyle(
-                  backgroundColor: WidgetStateProperty.all<Color?>(
-                    FluentTheme.of(context).accentColor,
+              IntrinsicWidth(
+                child: SizedBox(
+                  height: 32,
+                  child: AdaptivePrimaryButton.createTitleOnly(
+                    onPressed: () {
+                      context.go(
+                        '${AppRoute.welcome.fullPath}/${AppRoute.initializeMode.path}',
+                      );
+                    },
+                    requestState: RequestStateEnum.loaded,
+                    title: context.tr(LocaleKeys.start_button_text),
                   ),
                 ),
-                text: LocaleKeys.start_button_text,
-                textColor: AppTheme.of(context)
-                    .extension<OnAccentPallet>()!
-                    .onAccentColor,
-                onPressed: () {
-                  context.go(
-                    '${AppRoute.welcome.fullPath}/${AppRoute.initializeMode.path}',
-                  );
-                },
               ),
               const Gap(50),
             ],


### PR DESCRIPTION
- update `CopyToClipboardButton` class
- update `FinishScreen`
- update `InitializeModeScreen`
- update `NavigationFooterSection`
- update `ValidatorConfigScreen`
- update `WelcomeScreen`